### PR TITLE
Refactored singleton patterns to allow more concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ The default configuration is as follows:
 
 ```
 de.unikiel.inf.comsys.neo4j.query.timeout = 120
-de.unikiel.inf.comsys.neo4j.inference.graph = urn:ontology
+de.unikiel.inf.comsys.neo4j.query.patterns = p,c,pc
+de.unikiel.inf.comsys.neo4j.inference.graph = urn:sparqlextension:ontology
 ```
 
 ## License

--- a/src/main/java/de/unikiel/inf/comsys/neo4j/RepositoryRegistry.java
+++ b/src/main/java/de/unikiel/inf/comsys/neo4j/RepositoryRegistry.java
@@ -31,21 +31,24 @@ public class RepositoryRegistry {
 			throws RepositoryException {
 		initRio();
 		Graph graph = new Neo4j2Graph(database);
-		Sail sail = new GraphSail((KeyIndexableGraph) graph);
+		String patterns = SPARQLExtensionProps.getProperty("query.patterns");
+		Sail sail = new GraphSail((KeyIndexableGraph) graph, patterns);
 		this.rep = new SailRepository(sail);
 		rep.initialize();
 	}
  
-    public static synchronized RepositoryRegistry getInstance(
+    public static RepositoryRegistry getInstance(
 		GraphDatabaseService database) throws RepositoryException {
 		RepositoryRegistry inst;
         if (!map.containsKey(database)) {
-			inst = new RepositoryRegistry(database);
-			map.put(database, inst);
-        } else {
-			inst = map.get(database);
-		}
-        return inst;
+			synchronized(RepositoryRegistry.class) {
+				if (!map.containsKey(database)) {
+					inst = new RepositoryRegistry(database);
+					map.put(database, inst);
+				}
+			}
+        }
+        return map.get(database);
     }
 	
 	public SailRepository getRepository() {

--- a/src/main/java/de/unikiel/inf/comsys/neo4j/SPARQLExtensionProps.java
+++ b/src/main/java/de/unikiel/inf/comsys/neo4j/SPARQLExtensionProps.java
@@ -7,44 +7,41 @@ import java.util.Properties;
 
 public class SPARQLExtensionProps {
 	
-	private static Properties props;
+	private static final SPARQLExtensionProps instance = new SPARQLExtensionProps();
 	private static final String prefix = "de.unikiel.inf.comsys.neo4j.";
+	
+	private final Properties props;
 	 
 	private SPARQLExtensionProps() {
-		
+		Properties defs = new Properties();
+		try {
+			defs.load(
+					SPARQLExtensionProps.class
+					.getResourceAsStream("default.properties"));
+		} catch (IOException ex) {
+			throw new RuntimeException(ex);
+		}
+		props = new Properties(defs);
+		InputStream in = SPARQLExtensionProps.class
+				.getResourceAsStream("/sparql-extension.properties");
+		if (in != null) {
+			try {
+				props.load(in);
+			} catch (IOException ex) {
+			}
+		}
 	}
 	
-    public static synchronized Properties getProperties() {
-        if (props == null) {
-			Properties defs = new Properties();
-			try {
-				defs.load(
-					SPARQLExtensionProps
-							.class
-							.getResourceAsStream("default.properties"));
-			} catch (IOException ex) {
-				throw new RuntimeException(ex);
-			}
-			props = new Properties(defs);
-			InputStream in = SPARQLExtensionProps
-				.class
-				.getResourceAsStream("/sparql-extension.properties");
-			if (in != null) {
-				try {
-					props.load(in);
-				} catch (IOException ex) {
-				}
-			}
-        }
-        return props;
-    }
+	public Properties getProperties() {
+		return props;
+	}
 	
 	public static String getProperty(String key) {
-		return getProperties().getProperty(prefix + key);
+		return instance.getProperties().getProperty(prefix + key);
 	}
 	
 	public static String getProperty(String key, String defaultValue) {
-		return getProperties().getProperty(prefix + key, defaultValue);
+		return instance.getProperties().getProperty(prefix + key, defaultValue);
 	}
 	
 }

--- a/src/main/resources/de/unikiel/inf/comsys/neo4j/default.properties
+++ b/src/main/resources/de/unikiel/inf/comsys/neo4j/default.properties
@@ -1,2 +1,3 @@
 de.unikiel.inf.comsys.neo4j.query.timeout = 120
-de.unikiel.inf.comsys.neo4j.inference.graph = urn:ontology
+de.unikiel.inf.comsys.neo4j.query.patterns = p,c,pc
+de.unikiel.inf.comsys.neo4j.inference.graph = urn:sparqlextension:ontology


### PR DESCRIPTION
Also includes:
- renaming default t-box graph from `urn:ontology` to `urn:sparqlextension:ontology`
- new property to allow changing the [triple pattern indices](https://github.com/tinkerpop/blueprints/wiki/Sail-Ouplementation#optimizing-triple-indices)
