### PR TITLE
Revert "Updated jersey dependency"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <blueprints.version>2.6.0</blueprints.version>
         <sesame.version>2.7.13</sesame.version>
         <junit.version>4.11</junit.version>
-        <jersey.version>1.18.1</jersey.version>
+        <jersey.version>1.9</jersey.version>
         <jackson.version>1.9.13</jackson.version>
         <owlapi.version>4.0.0</owlapi.version>
         <rs-api.version>2.0.1</rs-api.version>


### PR DESCRIPTION
This reverts commit 0d1808ff5a3a7e88305b461bfdd8ddba6ada5963.
Solving problems with failed tests because of jersesy version mismatch.
